### PR TITLE
Lighten parallax overlays

### DIFF
--- a/home.html
+++ b/home.html
@@ -198,25 +198,25 @@
     }
 
     .layer-1 {
-      background-image: linear-gradient(rgba(0,0,0,0.2), rgba(0,0,0,0.4)), url('parallax1.png');
+      background-image: linear-gradient(rgba(0,0,0,0.1), rgba(0,0,0,0.2)), url('parallax1.png');
       z-index: 1;
       top: 50vh; /* Stop at 50% from top */
     }
 
     .layer-2 {
-      background-image: linear-gradient(rgba(0,0,0,0.1), rgba(0,0,0,0.3)), url('parallax2.png');
+      background-image: linear-gradient(rgba(0,0,0,0.05), rgba(0,0,0,0.15)), url('parallax2.png');
       z-index: 2;
       top: calc(50vh + 100px); /* 100px offset from layer 1 */
     }
 
     .layer-3 {
-      background-image: linear-gradient(rgba(0,0,0,0.15), rgba(0,0,0,0.35)), url('parallax3.png');
+      background-image: linear-gradient(rgba(0,0,0,0.1), rgba(0,0,0,0.2)), url('parallax3.png');
       z-index: 3;
       top: calc(50vh + 200px); /* 200px offset from layer 1 */
     }
 
     .layer-4 {
-      background-image: linear-gradient(rgba(0,0,0,0.1), rgba(0,0,0,0.25)), url('parallax4.png');
+      background-image: linear-gradient(rgba(0,0,0,0.05), rgba(0,0,0,0.15)), url('parallax4.png');
       z-index: 4;
       top: calc(50vh + 300px); /* 300px offset from layer 1 */
     }


### PR DESCRIPTION
## Summary
- reduce opacity of black gradients so parallax images show through

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6866cf92087883338478848bb7ec3653